### PR TITLE
Since we're using Flake8 and black, we should put the 88-line ruler, …

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,7 @@
   "recommendations": [
     "EditorConfig.EditorConfig",
     "ms-python.black-formatter",
+    "ms-python.isort",
     "matangover.mypy",
     "ms-python.flake8"
   ]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,7 @@
   "[python]": {
     "editor.formatOnSave": true,
     "editor.defaultFormatter": "ms-python.black-formatter",
+    "editor.rulers": [88],
     "editor.codeActionsOnSave": {
       "source.organizeImports": "explicit"
     }


### PR DESCRIPTION
…which is black's default max line length + isort.args is available through ms-python.isort